### PR TITLE
feat: Add a lazy (one sheet at a time) implementation

### DIFF
--- a/python/fastexcel/__init__.py
+++ b/python/fastexcel/__init__.py
@@ -3,11 +3,22 @@ from typing import Generator
 import pandas as pd
 import pyarrow as pa
 
-from .fastexcel import read_excel
+from .fastexcel import read_excel, read_excel_lazy
 
 
 def load_excel_file(path: str) -> Generator[pd.DataFrame, None, None]:
     raw_record_batches = read_excel(path)
+
+    def iter_():
+        for raw_record_batch in raw_record_batches:
+            for record_batch in pa.ipc.open_stream(raw_record_batch):
+                yield record_batch.to_pandas()
+
+    return iter_()
+
+
+def load_excel_file_lazy(path: str) -> Generator[pd.DataFrame, None, None]:
+    raw_record_batches = read_excel_lazy(path)
 
     def iter_():
         for raw_record_batch in raw_record_batches:

--- a/python/fastexcel/fastexcel.pyi
+++ b/python/fastexcel/fastexcel.pyi
@@ -1,6 +1,16 @@
-def read_excel(path: str) -> list[bytes]:
-    """Reads an excel file and returns a list of bytes representing.
+from typing import Generator
 
-    Each bytes objects represents a sheet of the file as an Arrow RecordBatch,
+
+def read_excel_lazy(path: str) -> Generator[bytes, None, None]:
+    """Reads an excel file and returns a generator of bytes objects.
+
+    Each bytes object represents a sheet of the file as an Arrow RecordBatch,
+    serialized in Arrow's IPC format.
+    """
+
+def read_excel(path: str) -> list[bytes]:
+    """Reads an excel file and returns a list of bytes.
+
+    Each bytes object represents a sheet of the file as an Arrow RecordBatch,
     serialized in Arrow's IPC format.
     """

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{fs, io, sync::Arc, vec};
 
 use anyhow::{Context, Result};
 use arrow::{
@@ -33,6 +33,130 @@ fn alias_for_name(name: &str, fields: &[datatypes::Field]) -> String {
     }
 
     rec(name, fields, 0)
+}
+
+pub struct ExcelSheet {
+    name: String,
+    schema: datatypes::Schema,
+    data: calamine::Range<DataType>,
+}
+
+impl ExcelSheet {
+    pub fn try_from_workbook_and_name(
+        wb: &mut Xlsx<io::BufReader<fs::File>>,
+        name: String,
+    ) -> Result<Self> {
+        let data = wb
+            .worksheet_range(&name)
+            .with_context(|| format!("Sheet {name} not found"))?
+            .with_context(|| format!("Error while loading sheet {name}"))?;
+        let schema = arrow_schema_from_range(&data)
+            .with_context(|| format!("Could not create Arrow schema for sheet {name}"))?;
+        Ok(Self { name, schema, data })
+    }
+
+    pub fn to_record_batch(&self) -> Result<RecordBatch> {
+        let height = self.data.height();
+        let iter = self
+            .schema
+            .fields()
+            .iter()
+            .enumerate()
+            .map(|(col_idx, field)| {
+                (
+                    field.name(),
+                    match field.data_type() {
+                        datatypes::DataType::Boolean => {
+                            create_boolean_array(&self.data, col_idx, height)
+                        }
+                        datatypes::DataType::Int64 => create_int_array(&self.data, col_idx, height),
+                        datatypes::DataType::Float64 => {
+                            create_float_array(&self.data, col_idx, height)
+                        }
+                        datatypes::DataType::Utf8 => {
+                            create_string_array(&self.data, col_idx, height)
+                        }
+                        datatypes::DataType::Null => Arc::new(NullArray::new(height - 1)),
+                        _ => unreachable!(),
+                    },
+                )
+            });
+        RecordBatch::try_from_iter(iter)
+            .with_context(|| format!("Could not convert sheet {} to RecordBatch", &self.name))
+    }
+}
+
+pub struct ExcelFile {
+    workbook: Xlsx<io::BufReader<fs::File>>,
+}
+
+fn arrow_schema_from_range(range: &calamine::Range<DataType>) -> Result<datatypes::Schema> {
+    let mut fields = Vec::with_capacity(range.width());
+    for col_idx in 0..range.width() {
+        let col_type = get_column_type(range, col_idx);
+        let name = range
+            .get((0, col_idx))
+            .with_context(|| format!("could not get name of column {col_idx}"))?
+            .get_string()
+            .with_context(|| format!("could not convert data at col {col_idx} to string"))?;
+        fields.push(datatypes::Field::new(
+            &alias_for_name(name, &fields),
+            col_type,
+            true,
+        ));
+    }
+    Ok(datatypes::Schema::new(fields))
+}
+
+impl ExcelFile {
+    pub fn try_from_path(path: &str) -> Result<Self> {
+        let workbook: Xlsx<_> =
+            open_workbook(path).with_context(|| format!("Could not open workbook at {path}"))?;
+        Ok(Self { workbook })
+    }
+}
+
+pub struct ExcelSheetIterator {
+    file: ExcelFile,
+    idx: usize,
+}
+
+impl ExcelSheetIterator {
+    pub fn new(file: ExcelFile) -> Self {
+        Self { file, idx: 0 }
+    }
+}
+
+impl Iterator for ExcelSheetIterator {
+    type Item = Result<ExcelSheet>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.file.workbook.sheet_names().get(self.idx) {
+            Some(name) => {
+                self.idx += 1;
+                let name = name.to_owned();
+                Some(ExcelSheet::try_from_workbook_and_name(
+                    &mut self.file.workbook,
+                    name,
+                ))
+            }
+            None => None,
+        }
+    }
+}
+
+impl IntoIterator for ExcelFile {
+    type Item = Result<ExcelSheet>;
+
+    type IntoIter = ExcelSheetIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ExcelSheetIterator::new(self)
+    }
+}
+
+pub fn extract_sheets_iter(path: &str) -> Result<ExcelSheetIterator> {
+    Ok(ExcelFile::try_from_path(path)?.into_iter())
 }
 
 pub fn extract_sheets(path: &str) -> Result<Vec<RecordBatch>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,42 @@
 mod core;
 
 use anyhow::{Context, Result};
+use arrow::record_batch::RecordBatch;
 use pyo3::{prelude::*, types::PyBytes};
 
-use crate::core::{extract_sheets, record_batch_to_bytes};
+use crate::core::{extract_sheets, extract_sheets_iter, record_batch_to_bytes, ExcelSheetIterator};
+
+#[pyclass]
+struct PyExcelSheetIterator {
+    it: ExcelSheetIterator,
+}
+
+fn record_batch_to_pybytes<'p>(py: Python<'p>, rb: &RecordBatch) -> Result<&'p PyBytes> {
+    record_batch_to_bytes(rb).map(|bytes| PyBytes::new(py, bytes.as_slice()))
+}
+
+#[pymethods]
+impl PyExcelSheetIterator {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<'_, Self>, py: Python<'_>) -> Result<Option<PyObject>> {
+        match slf.it.next() {
+            None => Ok(None),
+            Some(sheet) => {
+                record_batch_to_pybytes(py, &sheet?.to_record_batch()?).map(|b| Some(b.into()))
+            }
+        }
+    }
+}
+
+#[pyfunction]
+fn read_excel_lazy(path: &str) -> Result<PyExcelSheetIterator> {
+    let sheets =
+        extract_sheets_iter(path).with_context(|| format!("could not load file at {path}"))?;
+    Ok(PyExcelSheetIterator { it: sheets })
+}
 
 /// Reads an excel file and returns a list of bytes representing. Each bytes objects
 /// represents a sheet of the file as an Arrow RecordBatch, serialized in the IPC format
@@ -23,5 +56,6 @@ fn read_excel<'p>(py: Python<'p>, path: &str) -> Result<Vec<&'p PyBytes>> {
 #[pymodule]
 fn fastexcel(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(read_excel, m)?)?;
+    m.add_function(wrap_pyfunction!(read_excel_lazy, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,8 @@ impl PyExcelSheetIterator {
     fn __next__(mut slf: PyRefMut<'_, Self>, py: Python<'_>) -> Result<Option<PyObject>> {
         match slf.it.next() {
             None => Ok(None),
-            Some(sheet) => {
-                record_batch_to_pybytes(py, &sheet?.to_record_batch()?).map(|b| Some(b.into()))
-            }
+            Some(sheet) => record_batch_to_pybytes(py, &RecordBatch::try_from(&sheet?)?)
+                .map(|b| Some(b.into())),
         }
     }
 }

--- a/test.py
+++ b/test.py
@@ -1,19 +1,21 @@
 import argparse
 
-import pandas as pd
-
 import fastexcel
 
-pd.set_option("display.max_columns", 500)
+
+def get_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file")
+    parser.add_argument("--lazy", action="store_true")
+    return parser.parse_args()
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("file")
-    args = parser.parse_args()
-    dfs = fastexcel.load_excel_file(args.file)
-    for df in dfs:
-        print(df.head(5))
+    args = get_args()
+    if args.lazy:
+        dfs = list(fastexcel.load_excel_file_lazy(args.file))
+    else:
+        dfs = fastexcel.load_excel_file(args.file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds the possibility to load every sheet lazily, by providing a `read_excel_lazy` method that returns an iterator over raw sheets.

No perf improvements in case of a single fat sheet like with our fat file (but also no downgrade, which is nice), but useful in case we have several sheets in the file. Memory consumption improved slightly (peak ~35M lower on my machine on the fat file), as we do not allocate the vec mentionned in this comment: https://github.com/jGundermann/fastexcel/blob/98c11356735335741b2469eae3d73adec9a44201/src/lib.rs#L12 since we're lazy now
